### PR TITLE
Update poetry2nix to resolve py 'cryptography' dependency issue.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698974481,
-        "narHash": "sha256-yPncV9Ohdz1zPZxYHQf47S8S0VrnhV7nNhCawY46hDA=",
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "4bb5e752616262457bc7ca5882192a564c0472d2",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1705060653,
-        "narHash": "sha256-puYyylgrBS4AFAHeyVRTjTUVD8DZdecJfymWJe7H438=",
+        "lastModified": 1714113962,
+        "narHash": "sha256-7nVz2XUgVtnTQIYcuuqdLjZL8ifb7W8jciT+Szsx920=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d",
+        "rev": "9245811b58905453033f1ef551f516cbee71c42c",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699786194,
-        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "lastModified": 1708335038,
+        "narHash": "sha256-ETLZNFBVCabo7lJrpjD6cAbnE11eDOjaQnznmg/6hAE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "rev": "e504621290a1fd896631ddbc5e9c16f4366c9f65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
On `nixpkgs-unstable` rev `2748d22` building `entangled` fails with a dependency hash issue

```shell
❯ nix run 'github:dom-verity/entangled.py/nix-flake#entangled'
trace: warning: Unknown cryptography version: '42.0.1'. Please update getCargoHash.
error: hash mismatch in fixed-output derivation '/nix/store/fbv5syzy99m8fsjsx5lklrbbjkqla76c-cryptography-42.0.1-vendor.tar.gz.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-Kq/TSoI1cm9Pwg5CulNlAADmxdq0oWbgymHeMErUtcE=
error: 1 dependencies of derivation '/nix/store/2z3qy57103wx337didlbyxsxyhdrjnhy-python3.11-cryptography-42.0.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/67c03zfh5pmjlpwl1a43naazawxhbpyl-python3.11-secretstorage-3.3.3.drv' failed to build
error: 1 dependencies of derivation '/nix/store/am4139rics8jvwl8gd3sa8x4sx1z4gpv-python3.11-keyring-24.3.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/9nzvlkzgk236hd186xjwy8j29qx7klvd-python3.11-twine-4.0.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/gpnvhvs6y4mzj5hvwmysngh06y5g2d07-python3.11-entangled-cli-2.0.2.drv' failed to build
```

According to https://discourse.nixos.org/t/poetry2nix-mismatch-cryptography-sha256-but-unable-to-modify/33897 this is a bug in `poetry2nix` that has been resolved.

Updating `inputs.poetry2nix` resolved the issue

```shell
❯ nix flake lock --update-input poetry2nix
warning: updating lock file '/tmp/entangled2/entangled.py/flake.lock':
• Updated input 'poetry2nix':
    'github:nix-community/poetry2nix/e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d' (2024-01-12)
  → 'github:nix-community/poetry2nix/9245811b58905453033f1ef551f516cbee71c42c' (2024-04-26)
• Updated input 'poetry2nix/nix-github-actions':
    'github:nix-community/nix-github-actions/4bb5e752616262457bc7ca5882192a564c0472d2' (2023-11-03)
  → 'github:nix-community/nix-github-actions/5163432afc817cf8bd1f031418d1869e4c9d5547' (2023-12-29)
• Updated input 'poetry2nix/treefmt-nix':
    'github:numtide/treefmt-nix/e82f32aa7f06bbbd56d7b12186d555223dc399d1' (2023-11-12)
  → 'github:numtide/treefmt-nix/e504621290a1fd896631ddbc5e9c16f4366c9f65' (2024-02-19)
❯ nix run '.#entangled'
Usage: entangled [-h] [-d] [-v] {new,brei,status,stitch,sync,tangle,watch} ...
```
